### PR TITLE
Fix xunit.runner.visualstudio package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,6 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed explicit PrivateAssets and IncludeAssets attributes from the xunit.runner.visualstudio package version reference in Directory.Packages.props.