### PR TITLE
Ensure that strings for each benchmark iteration are unqiue

### DIFF
--- a/test/Jaahas.StringCache.Benchmarks/StringCacheBenchmarks.cs
+++ b/test/Jaahas.StringCache.Benchmarks/StringCacheBenchmarks.cs
@@ -14,8 +14,9 @@ public class StringCacheBenchmarks {
     [GlobalSetup]
     public void Setup() {
         _stringsToIntern = new List<string>(Count);
+        var runId = Guid.CreateVersion7(TimeProvider.System.GetUtcNow());
         for (var i = 0; i < Count; i++) {
-            _stringsToIntern.Add(i.ToString());
+            _stringsToIntern.Add(string.Concat(i.ToString(), "_", runId));
         }
     }
     


### PR DESCRIPTION
Adds a UUID v7 for the current benchmark iteration as a suffix to the strings to be interned in the benchmark.